### PR TITLE
Set max bars

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BBWPC
 Type: Package
 Title: Calculator for BedrijfsBodemWaterPlan (BBWP)
-Version: 0.10.2
+Version: 0.10.3
 Authors@R: c(
     person("Gerard", "Ros", email = "gerard.ros@nmi-agro.nl", role = c("aut","cre")),
     person("Sven", "Verweij", email = "sven.verweij@nmi-agro.nl", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# BBWPC v0.10.3
+## Added
+* added visible bindings to `er_main` and `er_farm_aim`
+
+## Changed
+* Set maxima for the five eco scores to 15 and for `s_er_farm_tot` to 50.
+* Set maximum for `s_er_costs` to 175 and convert to percentage between 0 and 100
+* Set aim for landscape to 1 and set aim for water to 1 in case all fields have `B_SOILTYPE_AGR` "veen".
+* Update `test-er`
+
 # BBWPC v0.10.2
 ## Fixed
 * correction on calculation of `S_ER_FARM_SCORE`: now averaged over the five eco themes
@@ -21,7 +31,6 @@
 
 ## Added
 * visible binding `s_er_reward` added to `er_main`
-
 
 ## Changed
 * the field score is set equal to the farm score for Ecoregeling method

--- a/R/er_farm_aim.R
+++ b/R/er_farm_aim.R
@@ -16,7 +16,7 @@ er_farm_aim <- function(B_SOILTYPE_AGR, B_AREA, medalscore = "gold", farmscore =
   
   # add visual bindings
   . = type = soiltype = value.mis = value = farmid = NULL
-  code = value_min = value_max = choices = cf_farm_tot = cf_costs = NULL
+  code = value_min = value_max = choices = cf_farm_tot = cf_costs = cf_landscape = cf_water = NULL
   medalscores = er_th_farmtotal = er_th_costs = NULL
   
   # Load bbwp_parms
@@ -93,7 +93,7 @@ er_farm_aim <- function(B_SOILTYPE_AGR, B_AREA, medalscore = "gold", farmscore =
            c('cf_soil', 'cf_water','cf_climate', 'cf_biodiversity','cf_landscape'),
            c('B_CT_SOIL', 'B_CT_WATER','B_CT_CLIMATE','B_CT_BIO','B_CT_LANDSCAPE')) 
   
-  # setcolorder
+  # set colorder
   setcolorder(out.tgt,'farmid')
   
   # round values
@@ -114,6 +114,20 @@ er_farm_aim <- function(B_SOILTYPE_AGR, B_AREA, medalscore = "gold", farmscore =
     out.threshold[medalscores == "gold", er_th_costs := 175]
     out.threshold[medalscores == "silver", er_th_costs := 100]
     out.threshold[medalscores == "bronze", er_th_costs := 70]
+    
+    # set threshold of golden medal for landscape to 0.5 and
+    # remove thresholds of bronze and silver medal for landscape
+    out.threshold[medalscores == "gold", cf_landscape := 0.5]
+    out.threshold[medalscores == "silver", cf_landscape := NA_real_]
+    out.threshold[medalscores == "bronze", cf_landscape := NA_real_]
+ 
+    # if farm only includes peat soils, set threshold for water to 0.5 
+    if( all(grepl("veen",B_SOILTYPE_AGR)) == TRUE){
+    
+    out.threshold[medalscores == "gold", cf_water := 0.5]
+    out.threshold[medalscores == "silver", cf_water := NA_real_]
+    out.threshold[medalscores == "bronze", cf_water := NA_real_]
+    }
     
     # update name to set absolute thresholds
     setnames(out.threshold,

--- a/R/er_main.R
+++ b/R/er_main.R
@@ -35,6 +35,7 @@ ecoregeling <- function(B_SOILTYPE_AGR, B_LU_BRP,B_LU_BBWP,
   # add visual bindings
   S_ER_TOT = S_ER_SOIL = S_ER_WATER = S_ER_CLIMATE = S_ER_BIODIVERSITY = S_ER_LANDSCAPE = S_ER_REWARD = NULL
   medal = s_er_medal = field_id = s_er_reward = s_er_tot = s_er_costs = NULL
+  s_er_soil = s_er_water = s_er_climate = s_er_biodiversity = s_er_landscape = s_er_farm_tot = NULL 
   
   # check wrapper inputs that are not checked in the bbwp functions
   checkmate::assert_character(output)
@@ -190,8 +191,16 @@ ecoregeling <- function(B_SOILTYPE_AGR, B_LU_BRP,B_LU_BBWP,
     out.farm[, s_er_reward := dt.farm$S_ER_REWARD]
     out.farm[, s_er_tot := dt.opi$dt.farm.score]
     
-    # set maximum for s_er_costs
-    out.farm[, s_er_costs := pmin(250,s_er_costs)]
+    # set maximum for s_er_costs at 175 and convert to percentage 
+    out.farm[, s_er_costs := (pmin(175,s_er_costs)/175)*100]
+    
+    # set maximum for eco scores and total farm scores on farm level
+    out.farm[, s_er_soil := pmin(15,s_er_soil)]
+    out.farm[, s_er_water := pmin(15,s_er_soil)]
+    out.farm[, s_er_climate := pmin(15,s_er_climate)]
+    out.farm[, s_er_biodiversity := pmin(15,s_er_biodiversity)]
+    out.farm[, s_er_landscape := pmin(1,s_er_landscape)]
+    out.farm[, s_er_farm_tot:= pmin(50,s_er_farm_tot)]
     
     # add thresholds
     out <- list(farm = as.list(out.farm),

--- a/tests/testthat/test-er.R
+++ b/tests/testthat/test-er.R
@@ -150,7 +150,7 @@ test <- ecoregeling(B_SOILTYPE_AGR = c('dekzand', 'loess', 'rivierklei'),
   test_that("check ecoregeling", {
     expect_equal(
       object = as.character(unlist(test$farm)),
-      expected = c(31,61,16,77,71,250,56,'gold',175,100),
+      expected = c(15,15,15,15,1,100,50,'gold',175,100),
       tolerance = 0.01)
   })
 


### PR DESCRIPTION
The maxima for eco_scores and costs are now fixed on 15, 50 or 100. The threshold scores of the golden medals for landscape and water are now set to 0.5. 
