### PR TITLE
Hotfix/bbwp23

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BBWPC
 Type: Package
 Title: Calculator for BedrijfsBodemWaterPlan (BBWP)
-Version: 0.10.12
+Version: 0.10.13
 Authors@R: c(
     person("Gerard", "Ros", email = "gerard.ros@nmi-agro.nl", role = c("aut","cre")),
     person("Sven", "Verweij", email = "sven.verweij@nmi-agro.nl", role = c("aut")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BBWPC
 Type: Package
 Title: Calculator for BedrijfsBodemWaterPlan (BBWP)
-Version: 0.10.11
+Version: 0.10.12
 Authors@R: c(
     person("Gerard", "Ros", email = "gerard.ros@nmi-agro.nl", role = c("aut","cre")),
     person("Sven", "Verweij", email = "sven.verweij@nmi-agro.nl", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# BBPC v.0.10.13
+
+## Fixed
+* farm measures were duplicated when BBWP-service combines field and farm measures. Duplicates are removed, issue #BBWP-23
+* `s_er_tot` in farm score of the er output is set to `s_er_farm_tot`
+* total area in pdf.5 in `er_pdf` is updated
+* avoid warnings in fs2 corrections in `er_meas_scores`
+
 # BBPC v.0.10.12
 
 ## Fixed

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# BBPC v.0.10.12
+
+## Fixed
+* farm-measure EB10 gives an error when no measures are given on field level, issue #BBWP-24
+
 # BBPC v.0.10.11
 
 ## Fixed

--- a/R/er_croprotation.R
+++ b/R/er_croprotation.R
@@ -70,10 +70,12 @@ er_croprotation <- function(B_SOILTYPE_AGR, B_AER_CBS,B_AREA,
   if(nrow(dt.meas.farm[grepl("EB10",eco_id)]) > 0){
     
     # replace EB10B or EB10C by EB10A
-    dt.meas.idx <- dt.meas.idx[, c("id","bbwp_status") := dt.meas.farm[grepl("EB10",eco_id),c("id","bbwp_status")]]
-    dt.meas.farm <- dt.meas.farm[!grepl("EB10",eco_id),]
-    dt.meas.farm <- rbind(dt.meas.farm,dt.meas.idx, use.names = TRUE, fill = TRUE)
-
+    ucols <- colnames(dt.meas.idx)
+    dt.meas.farm[grepl('EB10',eco_id), c(ucols) := dt.meas.idx[,mget(ucols)]]
+    
+    # farm measures should be unique
+    dt.meas.farm <- dt.meas.farm[!duplicated(eco_id)]
+    
     } else { 
     
     # add crop EB10A to farm measures  
@@ -168,7 +170,7 @@ er_croprotation <- function(B_SOILTYPE_AGR, B_AER_CBS,B_AREA,
     fs1 <- paste0('f',sector)
     fs2 <- fs0[!fs0 %in% fs1]
     dt.field[,c(fs1) := 1]
-    dt.field[,c(fs2) := 0]
+    if(length(fs2) > 0){dt.field[,c(fs2) := 0]}
     
     # estimate whether sector allows applicability
     dt.field[, fsector := fdairy * dairy + farable * arable + ftree_nursery * tree_nursery + fbulbs * bulbs] 
@@ -248,7 +250,7 @@ er_croprotation <- function(B_SOILTYPE_AGR, B_AER_CBS,B_AREA,
       fs1 <- paste0('f',sector)
       fs2 <- fs0[!fs0 %in% fs1]
       dt.meas.farm[,c(fs1) := 1]
-      dt.meas.farm[,c(fs2) := 0]
+      if(length(fs2)>0){dt.meas.farm[,c(fs2) := 0]}
       
       # estimate whether sector allows applicability
       dt.meas.farm[, fsector := fdairy * dairy + farable * arable + ftree_nursery * tree_nursery + fbulbs * bulbs] 

--- a/R/er_croprotation.R
+++ b/R/er_croprotation.R
@@ -33,7 +33,7 @@ er_croprotation <- function(B_SOILTYPE_AGR, B_AER_CBS,B_AREA,
   fr_soil = er_reward = fr_soil = reward_cf = regio_factor = euro_ha = oid = water = soil = climate = biodiversity = landscape = climate = total = NULL
   er_total = er_climate = er_soil = er_water = er_landscape = er_biodiversity = NULL
   eco_app = b_lu_arable_er = b_lu_productive_er = b_lu_cultivated_er = NULL
-  code = choices = cfr = B_IDX = k = combi = appl = area_appl = NULL
+  code = choices = cfr = B_IDX = k = combi = appl = area_appl = bbwp_status = NULL
   
   # Load bbwp_parms
   bbwp_parms <- BBWPC::bbwp_parms

--- a/R/er_croprotation.R
+++ b/R/er_croprotation.R
@@ -80,8 +80,11 @@ er_croprotation <- function(B_SOILTYPE_AGR, B_AER_CBS,B_AREA,
     
     # add crop EB10A to farm measures  
     dt.meas.farm <- rbind(dt.meas.farm,dt.meas.idx, use.names = TRUE, fill = TRUE)
-    dt.meas.farm <- dt.meas.farm[eco_id == 'EB10A', id := fifelse(is.na(id),1,id)]
-  
+    dt.meas.farm[eco_id == 'EB10A', id := fifelse(is.na(id),1,id)]
+    dt.meas.farm[eco_id == 'EB10A', bbwp_status := 'Planned']
+    
+    # farm measures should be unique
+    dt.meas.farm <- dt.meas.farm[!duplicated(eco_id)]
     } 
   
   # add bbwp table for financial reward correction factor per AER

--- a/R/er_main.R
+++ b/R/er_main.R
@@ -312,7 +312,7 @@ ecoregeling <- function(B_SOILTYPE_AGR, B_LU_BRP,B_LU_BBWP,
     cols <- c('oppervlakte','klim','bod','wat','land','bio')
     pdf.5 <- pdf.4[,lapply(.SD,function(x) round(weighted.mean(x,w = as.numeric(oppervlakte)),1)),.SDcols = cols,by=.(niveau)]
     pdf.5 <- rbind(pdf.5,data.table(niveau='totaal',round(t(colSums(pdf.5[,-1])),1)))
-    pdf.5[niveau=='total',oppervlakte :=  sum(B_AREA)]
+    pdf.5[niveau=='totaal',oppervlakte :=  round(sum(B_AREA/10000),1)]
     
     # table 6: score aim per theme for field and farm and medal thresholds per theme
     # get scores per field

--- a/R/er_main.R
+++ b/R/er_main.R
@@ -206,6 +206,9 @@ ecoregeling <- function(B_SOILTYPE_AGR, B_LU_BRP,B_LU_BBWP,
     out.farm[, s_er_landscape := pmin(dt.farm.thresholds$s_er_landscape_gold,s_er_landscape)]
     out.farm[, s_er_farm_tot:= pmin(dt.farm.thresholds$s_er_farmtotal_gold,s_er_farm_tot)]
     
+    # temporal solution to avoid BBWP score in screen
+    if(TRUE){out.farm[,s_er_tot := s_er_farm_tot]}
+    
     # add thresholds
     out <- list(farm = c(as.list(out.farm),dt.farm.thresholds),
                 fields = out.field)

--- a/R/er_meas_scores.R
+++ b/R/er_meas_scores.R
@@ -150,8 +150,8 @@ er_meas_score <- function(B_SOILTYPE_AGR, B_AER_CBS,B_AREA,
     fs1 <- paste0('f',sector)
     fs2 <- fs0[!fs0 %in% fs1]
     dt[,c(fs1) := 1]
-    dt[,c(fs2) := 0]
-    
+    if(length(fs2) > 0){dt.field[,c(fs2) := 0]}
+
     # estimate whether sector allows applicability
     dt[, fsector := fdairy * dairy + farable * arable + ftree_nursery * tree_nursery + fbulbs * bulbs] 
     

--- a/R/er_meas_scores.R
+++ b/R/er_meas_scores.R
@@ -150,7 +150,7 @@ er_meas_score <- function(B_SOILTYPE_AGR, B_AER_CBS,B_AREA,
     fs1 <- paste0('f',sector)
     fs2 <- fs0[!fs0 %in% fs1]
     dt[,c(fs1) := 1]
-    if(length(fs2) > 0){dt.field[,c(fs2) := 0]}
+    if(length(fs2) > 0){dt[,c(fs2) := 0]}
 
     # estimate whether sector allows applicability
     dt[, fsector := fdairy * dairy + farable * arable + ftree_nursery * tree_nursery + fbulbs * bulbs] 

--- a/R/er_pdf.R
+++ b/R/er_pdf.R
@@ -41,11 +41,11 @@ er_pdf <- function(croprotation,measurescores,dt.field.measures,dt.farm.measures
     pdf.meas.field <- merge(pdf.meas.field,dt1, by = "bbwp_id")
     
     # convert area to ha
-    pdf.meas.field <- pdf.meas.field[, B_AREA := B_AREA/10000]
+    pdf.meas.field[, B_AREA := B_AREA/10000]
     
     # add up scores and area if measures are applied on multiple fields
       # get total area of the measures applied on multiple fields
-      pdf.meas.field <- pdf.meas.field[, B_AREA_tot := sum(B_AREA), by = "summary"]
+      pdf.meas.field[, B_AREA_tot := sum(B_AREA), by = "summary"]
       
       # get cols
       cols <- c('climate','soil','water','landscape','biodiversity','total')
@@ -54,7 +54,7 @@ er_pdf <- function(croprotation,measurescores,dt.field.measures,dt.farm.measures
       pdf.meas.field <- pdf.meas.field[,lapply(.SD,weighted.mean,w = B_AREA), by = c("summary","bbwp_id","B_AREA_tot"),.SDcols = cols]
       
     # arrange table to right format
-    pdf.meas.field <- pdf.meas.field[, bbwp_id := NULL]
+    pdf.meas.field[, bbwp_id := NULL]
     pdf.meas.field[, level := "field"]
     setcolorder(pdf.meas.field, c("level","summary"))
     

--- a/R/er_pdf.R
+++ b/R/er_pdf.R
@@ -19,6 +19,9 @@ er_pdf <- function(croprotation,measurescores,dt.field.measures,dt.farm.measures
   pdf.farm.meas.name = pdf.farm.measures = pdf.field.tot = area_farm = pdf.tot = NULL
   total = euro_ha = euro_farm = bbwp_id = bbwp_measures = B_AREA_tot = NULL
   
+  # set farm measures to unique measures (no duplications allowed)
+  dt.farm.measures <- unique(dt.farm.measures)
+  
   # get internal measures table
   bbwp_measures <- as.data.table(BBWPC::bbwp_measures)
   
@@ -95,14 +98,15 @@ er_pdf <- function(croprotation,measurescores,dt.field.measures,dt.farm.measures
     
     # get measures applied on farm level
     pdf.farm.meas.name <- dt.farm.measures[total>0 | euro_farm > 0 | euro_ha > 0, c("bbwp_id")]
-    
+   
     # merge measure summary with applied measures
     pdf.farm.meas.name <- merge(pdf.farm.meas.name,
                                 dt1, by = "bbwp_id")
     
     # get applied measures and corresponding scores (in score per farm)
     pdf.farm.measures <- merge(pdf.farm.meas.name,
-                               dt.farm.measures[!is.na(bbwp_id), c("bbwp_id","climate","soil","water","landscape","biodiversity","total")], by = c('bbwp_id'))
+                               dt.farm.measures[!is.na(bbwp_id), c("bbwp_id","climate","soil","water","landscape","biodiversity","total")], 
+                               by = c('bbwp_id'))
     
     # get total farm area in ha
     area_farm = (sum(B_AREA)/10000)

--- a/tests/testthat/test-er.R
+++ b/tests/testthat/test-er.R
@@ -1,25 +1,26 @@
 require(testthat)
 
   # # default input for testing
-  B_SOILTYPE_AGR = c('dekzand', 'loess', 'rivierklei')
-  B_GWL_CLASS = c('GtIII', 'GtI', 'GtV')
-  B_AER_CBS = c('LG05','LG14','LG02')
-  A_P_SG = c(0.4, 0.8, 1)
-  B_SLOPE_DEGREE = c(1.5,4,1.5)
-  B_AER_CBS = c('LG05','LG14','LG02')
-  B_LU_BBWP = rep('gras_permanent',3)
-  B_LU_BRP = rep(265,3)
-  B_LU_ARABLE_ER = c(F,F,F)
-  B_LU_PRODUCTIVE_ER = c(T,T,T)
-  B_LU_CULTIVATED_ER = c(T,T,T)
-  M_DRAIN = c(TRUE, FALSE, TRUE)
-  D_SA_W = c(0, 0.5, 1)
-  B_AREA = c(1000000,800000,25000)
-  measures = NULL
-  farmscore = 100
-  sector = c('dairy', 'arable')
-  output = 'scores'
-  medalscore = 'gold'
+  # B_SOILTYPE_AGR = c('dekzand', 'loess', 'rivierklei')
+  # B_GWL_CLASS = c('GtIII', 'GtI', 'GtV')
+  # B_AER_CBS = c('LG05','LG14','LG02')
+  # A_P_SG = c(0.4, 0.8, 1)
+  # B_SLOPE_DEGREE = c(1.5,4,1.5)
+  # B_AER_CBS = c('LG05','LG14','LG02')
+  # B_LU_BBWP = rep('gras_permanent',3)
+  # B_LU_BRP = rep(265,3)
+  # B_LU_ARABLE_ER = c(F,F,F)
+  # B_LU_PRODUCTIVE_ER = c(T,T,T)
+  # B_LU_CULTIVATED_ER = c(T,T,T)
+  # M_DRAIN = c(TRUE, FALSE, TRUE)
+  # D_SA_W = c(0, 0.5, 1)
+  # B_AREA = c(1000000,800000,25000)
+  # measures = NULL
+  # farmscore = 100
+  # sector = c('dairy', 'arable')
+  # output = 'scores'
+  # medalscore = 'gold'
+  # pdf = FALSE
 
 # run example 1 without any measures taken
 test <- ecoregeling(B_SOILTYPE_AGR = c('dekzand', 'loess', 'rivierklei'),
@@ -142,7 +143,8 @@ test <- ecoregeling(B_SOILTYPE_AGR = c('dekzand', 'loess', 'rivierklei'),
                     farmscore = 100,
                     measures = measures,
                     sector = c('dairy', 'arable'),
-                    output = 'scores'
+                    medalscore = 'gold',
+                    output = 'scores',pdf=FALSE
 )
 
   # run tests on format and output values

--- a/tests/testthat/test-er.R
+++ b/tests/testthat/test-er.R
@@ -158,7 +158,7 @@ test <- ecoregeling(B_SOILTYPE_AGR = c('dekzand', 'loess', 'rivierklei'),
   test_that("check ecoregeling", {
     expect_equal(
       object = as.character(unlist(test$farm)),
-      expected = c(5.9,9.7,3.5,7.7,0,100,35,'silver',100,94,3.4,3.9,1.4,3.1,14,30,5.4,6.1,2.2,4.9,22,50,8.6,9.7,3.5,7.7,0,35,100),
+      expected = c(5.9,9.7,3.5,7.7,0,100,35,'silver',100,35,3.4,3.9,1.4,3.1,14,30,5.4,6.1,2.2,4.9,22,50,8.6,9.7,3.5,7.7,0,35,100),
       tolerance = 0.01)
   })
 

--- a/tests/testthat/test-er_croprotation.R
+++ b/tests/testthat/test-er_croprotation.R
@@ -92,7 +92,179 @@ test_that("check er_croprotation", {
     ignore_attr = TRUE)
 })
 
+# add test when only measurements on farm level are given
+dt.measures <- as.data.table(BBWPC::bbwp_measures)
+dt.measures <- dt.measures[!is.na(eco_id) & level=='farm']
+
+# make measurement list for 2 of the 4 fields
+measures <- rbind(data.table(id = 1, dt.measures[grepl('B189|G50|G3|B137|B172|G84',bbwp_id)]),
+                  data.table(id = 3, dt.measures[grepl('B135|G84|B118|G58|B146',bbwp_id)]))
+measures$bbwp_status <- 'given for ANLB'
+
+# run example 2 without any measures taken
+test <- er_croprotation(B_SOILTYPE_AGR = c('dekzand', 'loess', 'rivierklei','veen'),
+                        B_LU_BBWP = c('gras_permanent','rooivrucht','rooivrucht','mais'),
+                        B_LU_BRP = c(265,2741,2741,259),
+                        B_LU_ARABLE_ER = c(T,T,T,T),
+                        B_LU_PRODUCTIVE_ER = c(T,T,T,T),
+                        B_LU_CULTIVATED_ER = c(T,T,T,T),
+                        B_AER_CBS = c('Bouwhoek en Hogeland','LG14','LG12','Westelijk Holland'),
+                        B_AREA = c(450000,180000,8000,60000),
+                        measures = measures,
+                        sector = 'dairy'
+)
+
+test_that("check er_croprotation", {
+  expect_equal(
+    object = as.numeric(test),
+    expected = c(1,1.61,7.4,2.75,0,12.5,24.29,580.23),
+    tolerance = 0.1,
+    ignore_attr = TRUE)
+})
+
+# add test when only measurements on field level are given
+dt.measures <- as.data.table(BBWPC::bbwp_measures)
+dt.measures <- dt.measures[!is.na(eco_id) & level=='field']
+
+# make measurement list for 2 of the 4 fields
+measures <- rbind(data.table(id = 1, dt.measures[grepl('B189|G50|G3|B137|B172|G84',bbwp_id)]),
+                  data.table(id = 3, dt.measures[grepl('B135|G84|B118|G58|B146',bbwp_id)]))
+measures$bbwp_status <- 'given for ANLB'
+
+# run example 2 without any measures taken and insufficient crop diversificaiton
+test <- er_croprotation(B_SOILTYPE_AGR = c('dekzand', 'loess', 'rivierklei','veen'),
+                        B_LU_BBWP = c('gras_permanent','rooivrucht','rooivrucht','mais'),
+                        B_LU_BRP = c(265,2741,2741,259),
+                        B_LU_ARABLE_ER = c(T,T,T,T),
+                        B_LU_PRODUCTIVE_ER = c(T,T,T,T),
+                        B_LU_CULTIVATED_ER = c(T,T,T,T),
+                        B_AER_CBS = c('Bouwhoek en Hogeland','LG14','LG12','Westelijk Holland'),
+                        B_AREA = c(450000,180000,8000,60000),
+                        measures = measures,
+                        sector = 'dairy'
+)
+
+test_that("check er_croprotation", {
+  expect_equal(
+    object = as.numeric(test),
+    expected = c(1,0,0,0,0,0,0,0),
+    tolerance = 0.1,
+    ignore_attr = TRUE)
+})
+
+# add test when only measurements on field level are given
+dt.measures <- as.data.table(BBWPC::bbwp_measures)
+dt.measures <- dt.measures[!is.na(eco_id) & level=='field']
+
+# make measurement list for 2 of the 4 fields
+measures <- rbind(data.table(id = 1, dt.measures[grepl('B189|G50|G3|B137|B172|G84',bbwp_id)]),
+                  data.table(id = 3, dt.measures[grepl('B135|G84|B118|G58|B146',bbwp_id)]))
+measures$bbwp_status <- 'given for ANLB'
+
+# run example 2 without any measures taken and insufficient crop diversificaiton
+test <- er_croprotation(B_SOILTYPE_AGR = c('dekzand', 'loess', 'rivierklei','veen'),
+                        B_LU_BBWP = c('gras_permanent','rooivrucht','rooivrucht','mais'),
+                        B_LU_BRP = c(265,2741,2785,259),
+                        B_LU_ARABLE_ER = c(T,T,T,T),
+                        B_LU_PRODUCTIVE_ER = c(T,T,T,T),
+                        B_LU_CULTIVATED_ER = c(T,T,T,T),
+                        B_AER_CBS = c('Bouwhoek en Hogeland','LG14','LG12','Westelijk Holland'),
+                        B_AREA = c(450000,180000,8000,60000),
+                        measures = measures,
+                        sector = 'dairy'
+)
+
+test_that("check er_croprotation", {
+  expect_equal(
+    object = as.numeric(test),
+    expected = c(1,0.89,0,0.76,0.41,0.50,2.57,14.3),
+    tolerance = 0.1,
+    ignore_attr = TRUE)
+})
 
 
+# add test when only measurements on farm level are given
+dt.measures <- as.data.table(BBWPC::bbwp_measures)
+dt.measures <- dt.measures[!is.na(eco_id) & level=='farm']
 
+# make measurement list for 2 of the 4 fields
+measures <- rbind(data.table(id = 1, dt.measures[grepl('B190|B189|G50|G3|B137|B172|G84',bbwp_id)]),
+                  data.table(id = 3, dt.measures[grepl('B190|B191|G84|B118|G58|B146',bbwp_id)]))
+measures$bbwp_status <- 'given for ANLB'
 
+# run example 2 without any measures taken and sufficient crop diversificaiton
+test <- er_croprotation(B_SOILTYPE_AGR = c('dekzand', 'loess', 'rivierklei','veen'),
+                        B_LU_BBWP = c('gras_permanent','rooivrucht','rooivrucht','mais'),
+                        B_LU_BRP = c(265,2741,2785,259),
+                        B_LU_ARABLE_ER = c(T,T,T,T),
+                        B_LU_PRODUCTIVE_ER = c(T,T,T,T),
+                        B_LU_CULTIVATED_ER = c(T,T,T,T),
+                        B_AER_CBS = c('Bouwhoek en Hogeland','LG14','LG12','Westelijk Holland'),
+                        B_AREA = c(450000,180000,8000,60000),
+                        measures = measures,
+                        sector = 'dairy'
+)
+
+test_that("check er_croprotation", {
+  expect_equal(
+    object = as.numeric(test),
+    expected = c(1,2.5,2.02,0.76,0.41,4.98,10.67,580.2),
+    tolerance = 0.1,
+    ignore_attr = TRUE)
+})
+
+# add test when only measurements on farm level are given
+dt.measures <- as.data.table(BBWPC::bbwp_measures)
+dt.measures <- dt.measures[!is.na(eco_id) & level=='farm']
+
+# make measurement list for 2 of the 4 fields
+measures <- rbind(data.table(id = 1, dt.measures[grepl('B189|G50|G3|B137|B172|G84',bbwp_id)]),
+                  data.table(id = 3, dt.measures[grepl('B189|G84|B118|G58|B146',bbwp_id)]))
+measures$bbwp_status <- 'given for ANLB'
+
+# run example 2 without any measures taken and sufficient crop diversificaiton
+test <- er_croprotation(B_SOILTYPE_AGR = c('dekzand', 'loess', 'rivierklei','veen'),
+                        B_LU_BBWP = c('gras_permanent','rooivrucht','rooivrucht','mais'),
+                        B_LU_BRP = c(265,2741,2785,259),
+                        B_LU_ARABLE_ER = c(T,T,T,T),
+                        B_LU_PRODUCTIVE_ER = c(T,T,T,T),
+                        B_LU_CULTIVATED_ER = c(T,T,T,T),
+                        B_AER_CBS = c('Bouwhoek en Hogeland','LG14','LG12','Westelijk Holland'),
+                        B_AREA = c(450000,180000,8000,60000),
+                        measures = measures,
+                        sector = 'dairy'
+)
+
+test_that("check er_croprotation", {
+  expect_equal(
+    object = as.numeric(test),
+    expected = c(1,2.5,2.02,0.76,0.41,4.98,10.67,580.2),
+    tolerance = 0.1,
+    ignore_attr = TRUE)
+})
+
+# make measurement list for 2 of the 4 fields
+measures <- rbind(data.table(id = 1, dt.measures[grepl('G50|G3|B137|B172|G84',bbwp_id)]),
+                  data.table(id = 3, dt.measures[grepl('G84|B118|G58|B146',bbwp_id)]))
+measures$bbwp_status <- 'given for ANLB'
+
+# run example 2 without any measures taken and sufficient crop diversificaiton
+test <- er_croprotation(B_SOILTYPE_AGR = c('dekzand', 'loess', 'rivierklei','veen'),
+                        B_LU_BBWP = c('gras_permanent','rooivrucht','rooivrucht','mais'),
+                        B_LU_BRP = c(265,2741,2785,259),
+                        B_LU_ARABLE_ER = c(T,T,T,T),
+                        B_LU_PRODUCTIVE_ER = c(T,T,T,T),
+                        B_LU_CULTIVATED_ER = c(T,T,T,T),
+                        B_AER_CBS = c('Bouwhoek en Hogeland','LG14','LG12','Westelijk Holland'),
+                        B_AREA = c(450000,180000,8000,60000),
+                        measures = measures,
+                        sector = 'dairy'
+)
+
+test_that("check er_croprotation", {
+  expect_equal(
+    object = as.numeric(test),
+    expected = c(1,2.5,2.02,0.76,0.41,4.98,10.67,580.2),
+    tolerance = 0.1,
+    ignore_attr = TRUE)
+})


### PR DESCRIPTION
## Fixed
* farm measures were duplicated in BBWPC when BBWP-service combines field and farm measures. Duplicates are now removed, issue #BBWP-23
* `s_er_tot` in farm score of the er output is set to `s_er_farm_tot`
* total area in pdf.5 in `er_pdf` is updated
* avoid warnings in fs2 corrections in `er_meas_scores`