### PR TITLE
Set S_BBWP_GW weight to 0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BBWPC
 Type: Package
 Title: Calculator for BedrijfsBodemWaterPlan (BBWP)
-Version: 3.1.0
+Version: 3.1.1
 Authors@R: c(
     person("Gerard", "Ros", email = "gerard.ros@nmi-agro.nl", role = c("aut","cre")),
     person("Sven", "Verweij", email = "sven.verweij@nmi-agro.nl", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# BBWPC v3.1.1 2025-08-xx
+## Fixed
+* The new recently introduced score S_BBWP_GW weighing in in the calculation of 
+S_BBWP_TOT
+
+## Changed
+* Scores for S_BBWP_TOT are no longer affected by the groundwater recharge score.
+Total scores should be comparable again with those from V2.4.0
+
 # BBWPC v3.1.0 2025-08-04
 ## Added
 * BRP crop codes for 2025: 7137, 7138, 7135, 7134 [PL-40]

--- a/R/bbwp_field_scores.R
+++ b/R/bbwp_field_scores.R
@@ -221,14 +221,16 @@ bbwp_field_scores <- function(B_SOILTYPE_AGR, B_GWL_CLASS, A_P_CC,A_P_AL, B_SLOP
                       S_BBWP_NSW * wf(S_BBWP_NSW, type="score",penalty = penalty) + 
                       S_BBWP_PSW * wf(S_BBWP_PSW, type="score",penalty = penalty) + 
                       S_BBWP_NUE * wf(S_BBWP_NUE, type="score",penalty = penalty) + 
-                      S_BBWP_WB * wf(S_BBWP_WB, type="score",penalty = penalty) +
-                      S_BBWP_GW * wf(S_BBWP_GW, type="score",penalty = penalty)) /
+                      S_BBWP_WB * wf(S_BBWP_WB, type="score",penalty = penalty) #+
+                      # S_BBWP_GW * wf(S_BBWP_GW, type="score",penalty = penalty)
+                     ) /
         (wf(S_BBWP_NGW, type="score",penalty = penalty) + 
           wf(S_BBWP_NSW, type="score",penalty = penalty) +
           wf(S_BBWP_PSW, type="score",penalty = penalty) +  
           wf(S_BBWP_NUE, type="score",penalty = penalty) +
-          wf(S_BBWP_WB, type="score",penalty = penalty) +
-          wf(S_BBWP_GW, type="score",penalty = penalty))]
+          wf(S_BBWP_WB, type="score",penalty = penalty) #+
+          # wf(S_BBWP_GW, type="score",penalty = penalty)
+         )]
   
   # order the fields
   setorder(dt, id)

--- a/R/bbwp_meas_scores.R
+++ b/R/bbwp_meas_scores.R
@@ -209,7 +209,8 @@ bbwp_meas_score <- function(B_SOILTYPE_AGR, B_GWL_CLASS,  A_P_CC,A_P_AL, B_SLOPE
   scols <- c('D_MEAS_NGW','D_MEAS_NSW','D_MEAS_PSW','D_MEAS_NUE','D_MEAS_WB', 'D_MEAS_GW', 'D_MEAS_TOT')
   
   # Calculate total measure score
-  dt[, D_MEAS_TOT := (D_MEAS_NGW + D_MEAS_NSW + D_MEAS_PSW + D_MEAS_NUE + D_MEAS_WB + D_MEAS_GW) /  6]
+  # dt[, D_MEAS_TOT := (D_MEAS_NGW + D_MEAS_NSW + D_MEAS_PSW + D_MEAS_NUE + D_MEAS_WB + D_MEAS_GW) /  6]
+  dt[, D_MEAS_TOT := (D_MEAS_NGW + D_MEAS_NSW + D_MEAS_PSW + D_MEAS_NUE + D_MEAS_WB) /  5] # refrain from using GW in weighing of measures for now
   
   # set impact of conflict measures to the highest score of those that are selected
   

--- a/tests/testthat/test-bbwp.R
+++ b/tests/testthat/test-bbwp.R
@@ -113,7 +113,7 @@ require(BBWPC)
       
       expect_equal(
         object = test$fields$s_bbwp_tot,
-        expected = c(66, 50, 26),
+        expected = c(70, 45, 28),
         tolerance = 0.01)
       
       expect_equal(
@@ -256,12 +256,12 @@ require(BBWPC)
     # run tests on format and output values
     expect_equal(
       object = test$fields$s_bbwp_tot,
-      expected = c(83, 50, 54),
+      expected = c(91, 45, 64),
       tolerance = 0.01)
     
     expect_equal(
       object = as.numeric(unlist(test$farm)),
-      expected = c(68, 86 ,63 ,67 ,72, 92, 75),
+      expected = c(70, 86 ,63 ,67 ,72, 92, 75),
       tolerance = 0.01)
   })
 
@@ -317,7 +317,7 @@ require(BBWPC)
     
     expect_equal(
       object = test$fields$s_bbwp_tot,
-      expected = c(66 , 50 , 26),
+      expected = c(70 , 45 , 28),
       tolerance = 0.01)
     
     expect_equal(
@@ -368,7 +368,7 @@ require(BBWPC)
   test_that("check bbwp with high PSW loss risk", {
     expect_equal(
       object = as.numeric(unlist(test$farm)),
-      expected = c(29 , 87, 8, 6, 32, 91, 90),
+      expected = c(24 , 87, 8, 6, 32, 91, 90),
       tolerance = 0.01)
   })
   
@@ -414,7 +414,7 @@ require(BBWPC)
   test_that("check bbwp with high nitrate leaching risk and no measures", {
     expect_equal(
       object = as.numeric(unlist(test$farm)),
-      expected = c(58, 27, 55, 49, 82, 88, 91),
+      expected = c(53, 27, 55, 49, 82, 88, 91),
       tolerance = 0.01)
   })
   
@@ -458,7 +458,7 @@ require(BBWPC)
   test_that("check bbwp with low regional targets", {
     expect_equal(
       object = as.numeric(unlist(test$farm)),
-      expected = c(57, 87, 49, 43, 32, 84, 90),
+      expected = c(53, 87, 49, 43, 32, 84, 90),
       tolerance = 0.01)
   })
   

--- a/tests/testthat/test-bbwp_field_scores.R
+++ b/tests/testthat/test-bbwp_field_scores.R
@@ -61,7 +61,7 @@ test_that("check bbwp_field_scores", {
       S_BBWP_NUE = c(98,60,28),
       S_BBWP_WB = c(97,60,4),
       S_BBWP_GW = c(98,83,4),
-      S_BBWP_TOT = c(98,58,6)
+      S_BBWP_TOT = c(98,55,6)
     ),
     tolerance = 0.01)
 })
@@ -115,7 +115,7 @@ test_that("check bbwp_field_scores", {
       S_BBWP_NUE = c(99,60,100),
       S_BBWP_WB = c(98,60,26),
       S_BBWP_GW = c(99,83,16),
-      S_BBWP_TOT = c(99,58,37)
+      S_BBWP_TOT = c(99,55,44)
     ),
     tolerance = 0.01)
 })

--- a/tests/testthat/test-bbwp_gw_recharge.R
+++ b/tests/testthat/test-bbwp_gw_recharge.R
@@ -211,7 +211,7 @@ test_that("M_DRAIN affect GWL class IIIb and IV but not others", {
                  M_GREEN = c(FALSE, FALSE),
                  B_LU_BRP = c(265, 2014)
   )
-  expect_false(drainT$farm$s_bbwp_tot == drainF$farm$s_bbwp_tot)
+  # expect_false(drainT$farm$s_bbwp_tot == drainF$farm$s_bbwp_tot) # as long as GW isn't included in the calculation of TOT, drainage will not affect the total score
   expect_false(drainT$farm$s_bbwp_gw == drainF$farm$s_bbwp_gw)
   expect_true(drainT$farm$s_bbwp_wb == drainF$farm$s_bbwp_wb)
   expect_true(drainT$farm$s_bbwp_ngw == drainF$farm$s_bbwp_ngw)


### PR DESCRIPTION
A recent update to BBWPC introduced the score S_BBWP_GW. This score affected the total score as well. This PR excludes S_BBWP_GW from weighing in in the total score and effectiveness of measures. This way there is less of a hard change to users TOT score.